### PR TITLE
Add eslint-plugin-chai-friendly

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -23,7 +23,8 @@
     "promise",
     "standard",
     "react",
-    "jsx-a11y"
+    "jsx-a11y",
+    "chai-friendly"
   ],
 
   "globals": {
@@ -144,7 +145,8 @@
     "no-unreachable": "error",
     "no-unsafe-finally": "error",
     "no-unsafe-negation": "error",
-    "no-unused-expressions": ["error", { "allowShortCircuit": true, "allowTernary": true, "allowTaggedTemplates": true }],
+    "no-unused-expressions": 0,
+    "chai-friendly/no-unused-expressions": ["error", { "allowShortCircuit": true, "allowTernary": true, "allowTaggedTemplates": true }],
     "no-unused-vars": ["error", { "vars": "all", "args": "none", "ignoreRestSiblings": true }],
     "no-use-before-define": ["error", { "functions": false, "classes": false, "variables": false }],
     "no-useless-call": "error",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "homepage": "https://github.com/GuildEducationInc/eslint-config-guild#readme",
   "dependencies": {
+    "eslint-plugin-chai-friendly": "^0.4.1",
     "eslint-plugin-import": "^2.7.0",
     "eslint-plugin-jsx-a11y": "^6.0.2",
     "eslint-plugin-node": "^5.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -135,6 +135,10 @@ eslint-module-utils@^2.1.1:
     debug "^2.6.8"
     pkg-dir "^1.0.0"
 
+eslint-plugin-chai-friendly@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-chai-friendly/-/eslint-plugin-chai-friendly-0.4.1.tgz#9eeb17f92277ba80bb64f0e946c6936a3ae707b4"
+
 eslint-plugin-import@^2.7.0:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.7.0.tgz#21de33380b9efb55f5ef6d2e210ec0e07e7fa69f"


### PR DESCRIPTION
Adds `eslint-plugin-chai-friendly` to bring the shared config inline with what is being used in Genesis currently