### PR TITLE
Add Cypress and cy to allowed global variables, reject overwriting them

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -32,7 +32,9 @@
   "globals": {
     "document": false,
     "navigator": false,
-    "window": false
+    "window": false,
+    "cy": false,
+    "Cypress": false
   },
 
   "extends": [


### PR DESCRIPTION
Adds `Cypress` and `cy` as allowed global variables to support Cypress integration testing